### PR TITLE
Stub out a contributing doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,10 @@
+# Contributing to Portable SIMD
+
+Welcome to the Portable SIMD project group!
+
+## Where's the source code?
+
+See the [`rust-lang/stdsimd`](https://github.com/rust-lang/stdsimd) repository for the `std::simd` implementation.
+All questions, feature requests, bugs, and pull requests related to `std::simd` should be directed to `rust-lang/stdsimd` instead of here.
+
+This repository is for the project group itself and writing supporting materials for `std::simd`.


### PR DESCRIPTION
Creates an initial contributing doc pointing users to `stdsimd` for anything related to `std::simd`.